### PR TITLE
Switch database collection from `plasma` to `locations`

### DIFF
--- a/new-website/src/components/location/index.jsx
+++ b/new-website/src/components/location/index.jsx
@@ -11,7 +11,7 @@ import { FormattedMessage, useIntl } from "gatsby-plugin-intl"
 import MuiAlert from "@material-ui/lab/Alert"
 import { ErrorBoundary } from "../error/error-boundary"
 
-export const LOCATION_COLLECTION = "plasma"
+export const LOCATION_COLLECTION = "locations"
 
 /**
  * Fixes the issue with building the pages since

--- a/rules/firestore.rules
+++ b/rules/firestore.rules
@@ -1,53 +1,53 @@
 rules_version = '2';
 service cloud.firestore {
-	function isSignedIn(auth) {
-  	return auth != null && request.auth.token.email_verified;
+  function isSignedIn(auth) {
+    return auth != null && request.auth.token.email_verified;
   }
   match /databases/{database}/documents {
     function userIsMemberOfPartnerInResource(resource, request) {
-   		return resource.data.partnerID in get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partnerIds;
-  	}
+      return resource.data.partnerID in get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partnerIds;
+    }
     function request_userIsMemberOfPartner(resource, request) {
-   		return request.resource.data.partnerID in get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partnerIds;
-  	}
+      return request.resource.data.partnerID in get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partnerIds;
+    }
     function userIsMemberOfPartnerInResourceOLD(resource, request) {
-   		return resource.data.partnerID == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partner;
-  	}
+      return resource.data.partnerID == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partner;
+    }
     function request_userIsMemberOfPartnerOLD(resource, request) {
-   		return request.resource.data.partnerID == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partner;
-  	}
+      return request.resource.data.partnerID == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partner;
+    }
     function isAdmin(partnerId, request) {
       return get(/databases/$(database)/documents/partner/$(partnerId)/roles/$(request.auth.uid)).data.role == "admin"
     }
-  	match /blutspendende/{blutspendendeId} {
-    	allow read;
+    match /blutspendende/{blutspendendeId} {
+      allow read;
       allow delete, update: if isSignedIn(request.auth)  && (userIsMemberOfPartnerInResource(resource, request) || userIsMemberOfPartnerInResourceOLD(resource, request))
-   		allow create: if isSignedIn(request.auth)  &&  (request_userIsMemberOfPartner(resource, request) || request_userIsMemberOfPartnerOLD(resource, request))
-   }
-   match /plasma/{plasmaId} {
-    	allow read;
+      allow create: if isSignedIn(request.auth)  &&  (request_userIsMemberOfPartner(resource, request) || request_userIsMemberOfPartnerOLD(resource, request))
+    }
+    match /plasma/{plasmaId} {
+      allow read;
       allow delete, update: if isSignedIn(request.auth)  && (userIsMemberOfPartnerInResource(resource, request) || userIsMemberOfPartnerInResourceOLD(resource, request))
-   		allow create: if isSignedIn(request.auth)  &&  (request_userIsMemberOfPartner(resource, request) || request_userIsMemberOfPartnerOLD(resource, request))
-   }
+      allow create: if isSignedIn(request.auth)  &&  (request_userIsMemberOfPartner(resource, request) || request_userIsMemberOfPartnerOLD(resource, request))
+    }
     match /partner/{partnerId} {
-    	allow read: if isSignedIn(request.auth) && exists(/databases/$(database)/documents/partner/$(partnerId)/roles/$(request.auth.uid))
-    	allow write: if false;
+      allow read: if isSignedIn(request.auth) && exists(/databases/$(database)/documents/partner/$(partnerId)/roles/$(request.auth.uid))
+      allow write: if false;
     }
     match /partner/{partnerId}/roles/{userId} {
-    	allow read,write: if false;
+      allow read,write: if false;
     }
     match /partner/{partnerId}/invites/{inviteId} {
-    	allow read,write: if isSignedIn(request.auth) && isAdmin(partnerId, request)
+      allow read,write: if isSignedIn(request.auth) && isAdmin(partnerId, request)
     }
     match /heros/{heroId} {
-    	allow read, write: if false;
+      allow read, write: if false;
     }
     match /mail/{mailId} {
-    	allow read, write: if false;
+      allow read, write: if false;
     }
     match /users/{userId} {
       allow read: if isSignedIn(request.auth) && request.auth.uid == userId;
-    	allow write: if false;
+      allow write: if false;
     }
   }
 }

--- a/rules/firestore.rules
+++ b/rules/firestore.rules
@@ -13,7 +13,7 @@ service cloud.firestore {
     function isAdmin(partnerId, request) {
       return get(/databases/$(database)/documents/partner/$(partnerId)/roles/$(request.auth.uid)).data.role == "admin"
     }
-    match /plasma/{plasmaId} {
+    match /locations/{docId} {
       allow read;
       allow delete, update: if isSignedIn(request.auth) && requestingUserIsMemberOfPartnerOwningResource(resource, request)
       allow create: if isSignedIn(request.auth) && requestingUserIsMemberOfPartner(resource, request)

--- a/rules/firestore.rules
+++ b/rules/firestore.rules
@@ -4,30 +4,19 @@ service cloud.firestore {
     return auth != null && request.auth.token.email_verified;
   }
   match /databases/{database}/documents {
-    function userIsMemberOfPartnerInResource(resource, request) {
+    function requestingUserIsMemberOfPartnerOwningResource(resource, request) {
       return resource.data.partnerID in get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partnerIds;
     }
-    function request_userIsMemberOfPartner(resource, request) {
+    function requestingUserIsMemberOfPartner(resource, request) {
       return request.resource.data.partnerID in get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partnerIds;
-    }
-    function userIsMemberOfPartnerInResourceOLD(resource, request) {
-      return resource.data.partnerID == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partner;
-    }
-    function request_userIsMemberOfPartnerOLD(resource, request) {
-      return request.resource.data.partnerID == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.partner;
     }
     function isAdmin(partnerId, request) {
       return get(/databases/$(database)/documents/partner/$(partnerId)/roles/$(request.auth.uid)).data.role == "admin"
     }
-    match /blutspendende/{blutspendendeId} {
-      allow read;
-      allow delete, update: if isSignedIn(request.auth)  && (userIsMemberOfPartnerInResource(resource, request) || userIsMemberOfPartnerInResourceOLD(resource, request))
-      allow create: if isSignedIn(request.auth)  &&  (request_userIsMemberOfPartner(resource, request) || request_userIsMemberOfPartnerOLD(resource, request))
-    }
     match /plasma/{plasmaId} {
       allow read;
-      allow delete, update: if isSignedIn(request.auth)  && (userIsMemberOfPartnerInResource(resource, request) || userIsMemberOfPartnerInResourceOLD(resource, request))
-      allow create: if isSignedIn(request.auth)  &&  (request_userIsMemberOfPartner(resource, request) || request_userIsMemberOfPartnerOLD(resource, request))
+      allow delete, update: if isSignedIn(request.auth) && requestingUserIsMemberOfPartnerOwningResource(resource, request)
+      allow create: if isSignedIn(request.auth) && requestingUserIsMemberOfPartner(resource, request)
     }
     match /partner/{partnerId} {
       allow read: if isSignedIn(request.auth) && exists(/databases/$(database)/documents/partner/$(partnerId)/roles/$(request.auth.uid))


### PR DESCRIPTION
With PR https://github.com/ImmunHelden/ImmunHelden.de/pull/156 the map finally reads pin locations and details from the database collection `locations`. So it's time to adapt access rules and change the collection we access from the Partners side. e8407ea should be the only functional change. Apparently the change needs to be deployed to firebase in oder to get tested.